### PR TITLE
Create tests for new flush operation

### DIFF
--- a/sdk/redis/Azure.ResourceManager.Redis/assets.json
+++ b/sdk/redis/Azure.ResourceManager.Redis/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "net",
   "TagPrefix": "net/redis/Azure.ResourceManager.Redis",
-  "Tag": "net/redis/Azure.ResourceManager.Redis_40dabd49d3"
+  "Tag": "net/redis/Azure.ResourceManager.Redis_5ce806bbfd"
 }

--- a/sdk/redis/Azure.ResourceManager.Redis/tests/ScenarioTests/FlushFunctionalTests.cs
+++ b/sdk/redis/Azure.ResourceManager.Redis/tests/ScenarioTests/FlushFunctionalTests.cs
@@ -1,0 +1,56 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Threading.Tasks;
+using Azure.ResourceManager.Redis.Models;
+using Azure.ResourceManager.Resources;
+using NUnit.Framework;
+
+namespace Azure.ResourceManager.Redis.Tests.ScenarioTests
+{
+    public class FlushFunctionalTests : RedisManagementTestBase
+    {
+        private ResourceGroupResource ResourceGroup { get; set; }
+        private RedisCollection Collection { get; set; }
+        public FlushFunctionalTests(bool isAsync)
+                    : base(isAsync) //, RecordedTestMode.Record)
+        {
+        }
+
+        private async Task SetCollectionsAsync()
+        {
+            ResourceGroup = await CreateResourceGroupAsync();
+            Collection = ResourceGroup.GetAllRedis();
+        }
+        [Test]
+        public async Task FlushInvocationTest()
+        {
+            // Create cache
+            await SetCollectionsAsync();
+            string redisCacheName = Recording.GenerateAssetName("RedisFlush");
+            RedisCreateOrUpdateContent redisCreationParameters = new RedisCreateOrUpdateContent(DefaultLocation, new RedisSku(RedisSkuName.Standard, RedisSkuFamily.BasicOrStandard, 1));
+            RedisResource redisResource = (await Collection.CreateOrUpdateAsync(WaitUntil.Completed, redisCacheName, redisCreationParameters)).Value;
+            // Execute flush
+            await redisResource.FlushCacheAsync(WaitUntil.Completed);
+        }
+        [Test]
+        public async Task FlushValidationFailureTest()
+        {
+            // Create cache
+            await SetCollectionsAsync();
+            string redisCacheName = Recording.GenerateAssetName("RedisFlush");
+            RedisCreateOrUpdateContent redisCreationParameters = new RedisCreateOrUpdateContent(DefaultLocation, new RedisSku(RedisSkuName.Standard, RedisSkuFamily.BasicOrStandard, 1));
+            RedisResource redisResource = (await Collection.CreateOrUpdateAsync(WaitUntil.Completed, redisCacheName, redisCreationParameters)).Value;
+
+            // Scale cache so that it doesn't except flush requests
+            RedisPatch redisPatch = new RedisPatch()
+            {
+                Sku = new RedisSku(RedisSkuName.Standard, RedisSkuFamily.BasicOrStandard, 2)
+            };
+            await redisResource.UpdateAsync(WaitUntil.Started, redisPatch);
+
+            // Validate the flush request throws exception
+            Assert.ThrowsAsync<Azure.RequestFailedException>(() => redisResource.FlushCacheAsync(WaitUntil.Completed));
+        }
+    }
+}

--- a/sdk/redis/test-resources.json
+++ b/sdk/redis/test-resources.json
@@ -1,0 +1,6 @@
+{
+    "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+    "contentVersion": "1.0.0.0",
+    "resources": [
+    ]
+}


### PR DESCRIPTION
Adds tests for the new flush operation. Recordings have been pushed to the `Azure/azure-sdk-assets` repository, hence bumping the tag in `assets.json`. 

This PR also adds an effectively empty `test-resources.json` in the `sdk/redis` directory. I found that this was necessary to run the `New-TestResources.ps1` initialization script. 